### PR TITLE
if package version isn't specified do not use it in url

### DIFF
--- a/lib/boxcar/command/package.rb
+++ b/lib/boxcar/command/package.rb
@@ -24,7 +24,11 @@ class Boxcar::Command::Package < Boxcar::Command::Base
     version = args[1]
     persist = args[2] == "--persist"
 
-    response = HTTParty.get("#{addons_host}/packages/#{name}/#{version}")
+    if version
+      response = HTTParty.get("#{addons_host}/packages/#{name}/#{version}")
+    else
+      response = HTTParty.get("#{addons_host}/packages/#{name}")
+    end
     pkg = JSON.parse(response.body)
 
     if pkg.any?


### PR DESCRIPTION
trailing slash was being added when version wasn't specified, which would point to the wrong url.
